### PR TITLE
feat: adopt the bookshelf SDK in the generated feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# The generated feedstock's lock file. `_tasks` writes it only when absent, so a committed
+# copy would pin one SDK commit forever and never refresh.
+tests/regression/ctt/defaults/uv.lock

--- a/actions/record-bundle/action.yml
+++ b/actions/record-bundle/action.yml
@@ -62,7 +62,7 @@ runs:
         RECIPE: ${{ inputs.recipe }}
         BUNDLE: ${{ inputs.bundle }}
       run: >-
-        uv run bookshelf record "${BUILD_FILE}"
+        uv run python "${GITHUB_ACTION_PATH}/record_bundle.py" "${BUILD_FILE}"
         --recipe "${RECIPE}"
         --bundle "${BUNDLE}"
 

--- a/actions/record-bundle/publish_bundle.py
+++ b/actions/record-bundle/publish_bundle.py
@@ -1,15 +1,14 @@
 """Replay a bundle and report whether publishing converged on an edition."""
 
 import argparse
-import asyncio
 import json
 from pathlib import Path
 
-from bookshelf_client import Bookshelf, replay
-from bookshelf_client.bundle import Bundle, compute_book_bundle_hash
+from bookshelf import Bookshelf
+from bookshelf.publisher import Bundle, compute_book_bundle_hash, replay_bundle_sync
 
 
-async def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
+def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
     """Replay a bundle and return a machine readable publish outcome."""
     bundle = Bundle.read(root)
     framing = bundle.manifest.book
@@ -17,10 +16,11 @@ async def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
         raise ValueError("bundle has no book framing")
 
     bundle_hash = compute_book_bundle_hash(bundle.manifest)
-    async with Bookshelf(base_url, token, mode="online") as client:
-        existing = await client.create_draft_book(
+    with Bookshelf(base_url, auth=token) as client:
+        # The bundle hash selects an existing edition, so this probe is idempotent.
+        existing = client.draft_book(
             framing.volume,
-            framing.version,
+            version=framing.version,
             license=framing.license,
             visibility=framing.visibility,
             bundle_hash=bundle_hash,
@@ -30,27 +30,20 @@ async def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
                 "outcome": "no-op",
                 "volume": framing.volume,
                 "version": framing.version,
-                "edition": existing.edition,
+                "edition": existing.metadata.edition,
                 "bundle_hash": bundle_hash,
                 "resources": 0,
             }
 
-        artifacts = await replay(bundle, client)
-        published = await client.create_draft_book(
-            framing.volume,
-            framing.version,
-            license=framing.license,
-            visibility=framing.visibility,
-            bundle_hash=bundle_hash,
-        )
+        published = replay_bundle_sync(bundle, client)
 
     return {
         "outcome": "published",
         "volume": framing.volume,
         "version": framing.version,
-        "edition": published.edition,
+        "edition": published.metadata.edition,
         "bundle_hash": bundle_hash,
-        "resources": len(artifacts),
+        "resources": len(bundle.manifest.resources),
     }
 
 
@@ -61,7 +54,7 @@ def main() -> None:
     parser.add_argument("--base-url", required=True)
     parser.add_argument("--token", required=True)
     args = parser.parse_args()
-    print(json.dumps(asyncio.run(publish(args.bundle, args.base_url, args.token))))
+    print(json.dumps(publish(args.bundle, args.base_url, args.token)))
 
 
 if __name__ == "__main__":

--- a/actions/record-bundle/publish_bundle.py
+++ b/actions/record-bundle/publish_bundle.py
@@ -17,20 +17,27 @@ def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
 
     bundle_hash = compute_book_bundle_hash(bundle.manifest)
     with Bookshelf(base_url, auth=token) as client:
-        # The bundle hash selects an existing edition, so this probe is idempotent.
-        existing = client.draft_book(
+        # The bundle hash resolves to an existing edition or draft, which is how a
+        # rerun is told apart from a first publish. This repeats the call replay makes,
+        # so it has to send every framing field replay sends. A first run would
+        # otherwise create the draft without them, and replay would then resolve to
+        # that draft rather than fill them in.
+        drafted = client.draft_book(
             framing.volume,
             version=framing.version,
+            description=framing.description,
+            citation_doi=framing.citation_doi,
             license=framing.license,
             visibility=framing.visibility,
+            metadata=framing.metadata,
             bundle_hash=bundle_hash,
         )
-        if existing.status == "published":
+        if drafted.status == "published":
             return {
                 "outcome": "no-op",
                 "volume": framing.volume,
                 "version": framing.version,
-                "edition": existing.metadata.edition,
+                "edition": drafted.metadata.edition,
                 "bundle_hash": bundle_hash,
                 "resources": 0,
             }

--- a/actions/record-bundle/publish_bundle.py
+++ b/actions/record-bundle/publish_bundle.py
@@ -17,11 +17,9 @@ def publish(root: Path, base_url: str, token: str) -> dict[str, object]:
 
     bundle_hash = compute_book_bundle_hash(bundle.manifest)
     with Bookshelf(base_url, auth=token) as client:
-        # The bundle hash resolves to an existing edition or draft, which is how a
-        # rerun is told apart from a first publish. This repeats the call replay makes,
-        # so it has to send every framing field replay sends. A first run would
-        # otherwise create the draft without them, and replay would then resolve to
-        # that draft rather than fill them in.
+        # The bundle hash keys the draft, so a rerun resolves to the published edition.
+        # Replay repeats this call,
+        # so the framing sent here must match it field for field.
         drafted = client.draft_book(
             framing.volume,
             version=framing.version,

--- a/actions/record-bundle/record_bundle.py
+++ b/actions/record-bundle/record_bundle.py
@@ -1,0 +1,27 @@
+"""Execute a standalone Jupytext build file and record it into a bundle."""
+
+import argparse
+import json
+from pathlib import Path
+
+from bookshelf.publisher import run_record
+
+
+def main() -> None:
+    """Parse arguments and print a JSON record summary."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build", type=Path)
+    parser.add_argument("--recipe", type=Path, required=True)
+    parser.add_argument("--bundle", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = run_record(
+        build_path=args.build,
+        recipe_path=args.recipe,
+        bundle_path=args.bundle,
+    )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/actions/record-bundle/validate_bundle.py
+++ b/actions/record-bundle/validate_bundle.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from bookshelf_client.bundle import Bundle, compute_book_bundle_hash
+from bookshelf.publisher import Bundle, compute_book_bundle_hash
 
 
 def validate(root: Path) -> dict[str, object]:

--- a/changelog/11.breaking.md
+++ b/changelog/11.breaking.md
@@ -4,3 +4,4 @@ Moves the generated feedstock onto the Bookshelf SDK that now lives in the `book
 - `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence and authors come from `bookshelf.yaml`.
 - The build carries a single activity block, which is all a recorded build supports.
 - Recording, validating and replaying a bundle run through `bookshelf.publisher` because the SDK exposes no `record` or `publish` command.
+- Scaffolding sets the origin remote, writes `uv.lock` and makes the first commit, because recording derives provenance from git and CI syncs with `--locked`.

--- a/changelog/11.breaking.md
+++ b/changelog/11.breaking.md
@@ -1,0 +1,6 @@
+Moves the generated feedstock onto the Bookshelf SDK that now lives in the `bookshelf` package.
+
+- The dependency is `bookshelf[publish,dataframes]`, sourced from the `feat/adopt-bookshelf-sdk` branch until the SDK is released.
+- `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence and authors come from `bookshelf.yaml`.
+- The build carries a single activity block, which is all a recorded build supports.
+- Recording, validating and replaying a bundle run through `bookshelf.publisher` because the SDK exposes no `record` or `publish` command.

--- a/changelog/11.breaking.md
+++ b/changelog/11.breaking.md
@@ -1,7 +1,7 @@
 Moves the generated feedstock onto the Bookshelf SDK that now lives in the `bookshelf` package.
 
 - The dependency is `bookshelf[publish,dataframes]`, sourced from the `feat/adopt-bookshelf-sdk` branch until the SDK is released.
-- `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence and authors come from `bookshelf.yaml`.
+- `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence, visibility and authors come from `bookshelf.yaml`.
 - The build carries a single activity block, which is all a recorded build supports.
 - Recording, validating and replaying a bundle run through `bookshelf.publisher` because the SDK exposes no `record` or `publish` command.
 - Scaffolding sets the origin remote, writes `uv.lock` and makes the first commit, because recording derives provenance from git and CI syncs with `--locked`.

--- a/copier.yaml
+++ b/copier.yaml
@@ -47,8 +47,17 @@ _envops:
     trim_blocks: true
     lstrip_blocks: true
 
+# Recording derives provenance from git, so it needs an origin remote and a commit to point at.
+# CI syncs with --locked, so it needs a lock file committed alongside them.
+# Each task is guarded, so re-running the template never rewrites an existing repository.
 _tasks:
     - '[ ! -d ".git" ] && git init || exit 0'
+    - 'git remote get-url origin >/dev/null 2>&1 || git remote add origin {{ project_url }}'
+    - '[ -f uv.lock ] || uv lock'
     - 'git add .'
+    - >-
+      git rev-parse HEAD >/dev/null 2>&1
+      || git -c user.name="{{ author }}" -c user.email="{{ author_email }}"
+      commit -q -m "Initial scaffold from copier-bookshelf-dataset"
 
 _subdirectory: template

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -14,10 +14,6 @@ for line in sys.stdin:
 endef
 export PRINT_HELP_PYSCRIPT
 
-# TODO: Remove once a release of bookshelf is made
-export UV_PRERELEASE = allow
-
-
 .PHONY: help
 help:  ## print short description of each target
 	@python3 -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
@@ -49,9 +45,9 @@ virtual-environment:  ## update virtual environment, create a new one if it does
 	uvx pre-commit install
 
 run:  ## Record and validate the book bundle
-	uv run bookshelf record build.py --recipe bookshelf.yaml --bundle bundle
+	uv run python scripts/record-bundle.py
 	uv run python scripts/validate-bundle.py
 
 
-publish:  ## publish a new release of the project
-	uv run bookshelf publish bundle
+publish:  ## replay the recorded bundle to the Bookshelf API
+	uv run python scripts/publish-bundle.py

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -29,8 +29,12 @@ Set the public `BOOKSHELF_TOKEN_URL` repository variable to the WorkOS AuthKit t
 The generated publish caller uses `secrets: inherit`.
 The reusable publish job carries `environment: deploy`, so those environment secrets are resolved when that job starts.
 
-Identical inputs must create identical bytes and stable lineage identifiers.
+Identical inputs must create identical data bytes and stable lineage identifiers.
 Change the hardcoded `version` in `build.py` when publishing a new data version.
+
+The recorded bundle also carries the executed notebook, so its bundle hash covers the build source.
+Any edit to `build.py`, a comment included, produces a new bundle hash.
+Publishing after a source-only edit therefore creates a new edition whose data is unchanged.
 
 ## Releasing
 

--- a/template/bookshelf.yaml.jinja
+++ b/template/bookshelf.yaml.jinja
@@ -1,5 +1,6 @@
 collection: {{ dataset_name }}
 license: MIT
+visibility: public
 authors:
   - name: {{ author }}
     email: {{ author_email }}

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -58,7 +58,7 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# The collection, licence and authors come from bookshelf.yaml.
+# Under `make run` the collection, licence and authors come from bookshelf.yaml.
 client, draft = bookshelf.setup(version=version, visibility="public")
 
 # A recorded build carries exactly one activity block.

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -25,6 +25,9 @@ build_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/build/{version}"
 # # Fetch
 #
 # Replace this small cached example with a hash verified upstream input.
+# `input_sha256` is the contract, not the bytes below.
+# The cache is only written when it is absent,
+# so editing these bytes needs `.cache` cleared.
 
 # %%
 input_content = b"region,year,value\nWorld,2020,1.0\nWorld,2021,2.0\n"
@@ -32,6 +35,13 @@ input_content = b"region,year,value\nWorld,2020,1.0\nWorld,2021,2.0\n"
 
 class InputHashMismatchError(ValueError):
     """Raised when cached input bytes do not match their declared hash."""
+
+    def __init__(self, path: Path, actual: str, expected: str) -> None:
+        super().__init__(
+            f"{path} hashes to {actual}, but this build declares {expected}. "
+            "Update input_sha256 to accept the new bytes, "
+            "or delete the cached file to fetch the input again."
+        )
 
 
 def fetch_input(expected_sha256: str) -> Path:
@@ -43,7 +53,7 @@ def fetch_input(expected_sha256: str) -> Path:
 
     actual = f"sha256:{hashlib.sha256(cache.read_bytes()).hexdigest()}"
     if actual != expected_sha256:
-        raise InputHashMismatchError
+        raise InputHashMismatchError(cache, actual, expected_sha256)
     return cache
 
 

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -12,15 +12,14 @@ import hashlib
 from pathlib import Path
 from uuid import NAMESPACE_URL, uuid5
 
+import bookshelf
 import pandas as pd
-from bookshelf import Bookshelf
 
 # Stable identifiers keep identical builds byte deterministic.
 resource_namespace = "{{ project_url }}"
 raw_tracking_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/raw/{version}")
-raw_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/fetch/{version}")
-process_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/process/{version}")
 output_tracking_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/data/{version}")
+build_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/build/{version}")
 
 # %% [markdown]
 # # Fetch
@@ -59,37 +58,28 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-with Bookshelf() as client:
-    with client.activity(
-        kind="fetch",
-        config={"version": version},
-        activity_id=raw_activity_id,
-    ) as activity:
-        raw = activity.register(
-            raw_data,
-            type="tabular",
-            logical_key=f"{{ dataset_name }}/raw-{version}",
-            tracking_id=raw_tracking_id,
-        )
+# The collection, licence and authors come from bookshelf.yaml.
+client, draft = bookshelf.setup(version=version, visibility="public")
 
-    with client.activity(
-        kind="process",
-        config={"version": version},
-        activity_id=process_activity_id,
-    ) as activity:
-        data = activity.register(
-            processed_data,
-            type="timeseries",
-            logical_key=f"{{ dataset_name }}/data-{version}",
-            used=[raw.tracking_id],
-            tracking_id=output_tracking_id,
-        )
-
-    draft = client.draft_book(
-        "{{ dataset_name }}",
-        version=version,
-        license="MIT",
-        visibility="public",
+# A recorded build carries exactly one activity block.
+with client.activity(
+    kind="build",
+    config={"version": version},
+    activity_id=build_activity_id,
+) as activity:
+    raw = activity.register(
+        raw_data,
+        type="tabular",
+        logical_key=f"{{ dataset_name }}/raw-{version}",
+        tracking_id=raw_tracking_id,
     )
-    draft.attach(data, name_in_book="data")
-    draft.publish()
+    data = activity.register(
+        processed_data,
+        type="timeseries",
+        logical_key=f"{{ dataset_name }}/data-{version}",
+        used=[raw.tracking_id],
+        tracking_id=output_tracking_id,
+    )
+
+draft.attach(data, name_in_book="data")
+draft.publish()

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -58,7 +58,8 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# Under `make run` the collection, licence and authors come from bookshelf.yaml.
+# The collection, licence and authors come from bookshelf.yaml.
+# This file is executed by the recorder, so it does not construct a client itself.
 client, draft = bookshelf.setup(version=version, visibility="public")
 
 # A recorded build carries exactly one activity block.

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -68,9 +68,9 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# The collection, licence and authors come from bookshelf.yaml.
+# The collection, licence, visibility and authors come from bookshelf.yaml.
 # This file is executed by the recorder, so it does not construct a client itself.
-client, draft = bookshelf.setup(version=version, visibility="public")
+client, draft = bookshelf.setup(version=version)
 
 # A recorded build carries exactly one activity block.
 with client.activity(

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -5,7 +5,7 @@ description = "{{ dataset_description }}"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf-client[cli,publish,dataframes]>=0.3.1b4",
+    "bookshelf[publish,dataframes]",
     "pandas>=2.2",
 ]
 
@@ -14,3 +14,7 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
+
+[tool.uv.sources]
+# The SDK's record and replay surface is not on PyPI yet, so track the branch that carries it.
+bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -16,5 +16,6 @@ dev = [
 ]
 
 [tool.uv.sources]
-# The SDK's record and replay surface is not on PyPI yet, so track the branch that carries it.
+# No published release carries the SDK's record and replay surface, so this tracks a branch.
+# A branch is not a fixed point, so uv.lock is what makes a build reproducible.
 bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/template/scripts/publish-bundle.py
+++ b/template/scripts/publish-bundle.py
@@ -1,0 +1,15 @@
+"""Replay the recorded bundle to the Bookshelf API.
+
+Credentials are resolved by the SDK from the environment or a stored login.
+"""
+
+from pathlib import Path
+
+from bookshelf import Bookshelf
+from bookshelf.publisher import replay_bundle_sync
+
+with Bookshelf() as client:
+    book = replay_bundle_sync(Path("bundle"), client)
+
+detail = book.metadata
+print(f"{detail.series_name} {detail.version}_e{detail.edition:03} ({book.status})")

--- a/template/scripts/record-bundle.py
+++ b/template/scripts/record-bundle.py
@@ -1,0 +1,13 @@
+"""Execute the build file and record it into a reviewable bundle."""
+
+import json
+from pathlib import Path
+
+from bookshelf.publisher import run_record
+
+result = run_record(
+    build_path=Path("build.py"),
+    recipe_path=Path("bookshelf.yaml"),
+    bundle_path=Path("bundle"),
+)
+print(json.dumps(result, sort_keys=True))

--- a/template/scripts/validate-bundle.py
+++ b/template/scripts/validate-bundle.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from bookshelf_client.bundle import Bundle, compute_book_bundle_hash
+from bookshelf.publisher import Bundle, compute_book_bundle_hash
 
 bundle = Bundle.read(Path("bundle"))
 print(compute_book_bundle_hash(bundle.manifest))

--- a/tests/regression/ctt/defaults/Makefile
+++ b/tests/regression/ctt/defaults/Makefile
@@ -14,10 +14,6 @@ for line in sys.stdin:
 endef
 export PRINT_HELP_PYSCRIPT
 
-# TODO: Remove once a release of bookshelf is made
-export UV_PRERELEASE = allow
-
-
 .PHONY: help
 help:  ## print short description of each target
 	@python3 -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
@@ -49,9 +45,9 @@ virtual-environment:  ## update virtual environment, create a new one if it does
 	uvx pre-commit install
 
 run:  ## Record and validate the book bundle
-	uv run bookshelf record build.py --recipe bookshelf.yaml --bundle bundle
+	uv run python scripts/record-bundle.py
 	uv run python scripts/validate-bundle.py
 
 
-publish:  ## publish a new release of the project
-	uv run bookshelf publish bundle
+publish:  ## replay the recorded bundle to the Bookshelf API
+	uv run python scripts/publish-bundle.py

--- a/tests/regression/ctt/defaults/README.md
+++ b/tests/regression/ctt/defaults/README.md
@@ -29,8 +29,12 @@ Set the public `BOOKSHELF_TOKEN_URL` repository variable to the WorkOS AuthKit t
 The generated publish caller uses `secrets: inherit`.
 The reusable publish job carries `environment: deploy`, so those environment secrets are resolved when that job starts.
 
-Identical inputs must create identical bytes and stable lineage identifiers.
+Identical inputs must create identical data bytes and stable lineage identifiers.
 Change the hardcoded `version` in `build.py` when publishing a new data version.
+
+The recorded bundle also carries the executed notebook, so its bundle hash covers the build source.
+Any edit to `build.py`, a comment included, produces a new bundle hash.
+Publishing after a source-only edit therefore creates a new edition whose data is unchanged.
 
 ## Releasing
 

--- a/tests/regression/ctt/defaults/bookshelf.yaml
+++ b/tests/regression/ctt/defaults/bookshelf.yaml
@@ -1,5 +1,6 @@
 collection: example
 license: MIT
+visibility: public
 authors:
   - name: Tim Slim
     email: timslim@climate-resource.com

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -58,7 +58,7 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# The collection, licence and authors come from bookshelf.yaml.
+# Under `make run` the collection, licence and authors come from bookshelf.yaml.
 client, draft = bookshelf.setup(version=version, visibility="public")
 
 # A recorded build carries exactly one activity block.

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -25,6 +25,9 @@ build_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/build/{version}"
 # # Fetch
 #
 # Replace this small cached example with a hash verified upstream input.
+# `input_sha256` is the contract, not the bytes below.
+# The cache is only written when it is absent,
+# so editing these bytes needs `.cache` cleared.
 
 # %%
 input_content = b"region,year,value\nWorld,2020,1.0\nWorld,2021,2.0\n"
@@ -32,6 +35,13 @@ input_content = b"region,year,value\nWorld,2020,1.0\nWorld,2021,2.0\n"
 
 class InputHashMismatchError(ValueError):
     """Raised when cached input bytes do not match their declared hash."""
+
+    def __init__(self, path: Path, actual: str, expected: str) -> None:
+        super().__init__(
+            f"{path} hashes to {actual}, but this build declares {expected}. "
+            "Update input_sha256 to accept the new bytes, "
+            "or delete the cached file to fetch the input again."
+        )
 
 
 def fetch_input(expected_sha256: str) -> Path:
@@ -43,7 +53,7 @@ def fetch_input(expected_sha256: str) -> Path:
 
     actual = f"sha256:{hashlib.sha256(cache.read_bytes()).hexdigest()}"
     if actual != expected_sha256:
-        raise InputHashMismatchError
+        raise InputHashMismatchError(cache, actual, expected_sha256)
     return cache
 
 

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -12,15 +12,14 @@ import hashlib
 from pathlib import Path
 from uuid import NAMESPACE_URL, uuid5
 
+import bookshelf
 import pandas as pd
-from bookshelf import Bookshelf
 
 # Stable identifiers keep identical builds byte deterministic.
 resource_namespace = "https://github.com/climate-resource/ctt-project"
 raw_tracking_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/raw/{version}")
-raw_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/fetch/{version}")
-process_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/process/{version}")
 output_tracking_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/data/{version}")
+build_activity_id = uuid5(NAMESPACE_URL, f"{resource_namespace}/build/{version}")
 
 # %% [markdown]
 # # Fetch
@@ -59,37 +58,28 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-with Bookshelf() as client:
-    with client.activity(
-        kind="fetch",
-        config={"version": version},
-        activity_id=raw_activity_id,
-    ) as activity:
-        raw = activity.register(
-            raw_data,
-            type="tabular",
-            logical_key=f"example/raw-{version}",
-            tracking_id=raw_tracking_id,
-        )
+# The collection, licence and authors come from bookshelf.yaml.
+client, draft = bookshelf.setup(version=version, visibility="public")
 
-    with client.activity(
-        kind="process",
-        config={"version": version},
-        activity_id=process_activity_id,
-    ) as activity:
-        data = activity.register(
-            processed_data,
-            type="timeseries",
-            logical_key=f"example/data-{version}",
-            used=[raw.tracking_id],
-            tracking_id=output_tracking_id,
-        )
-
-    draft = client.draft_book(
-        "example",
-        version=version,
-        license="MIT",
-        visibility="public",
+# A recorded build carries exactly one activity block.
+with client.activity(
+    kind="build",
+    config={"version": version},
+    activity_id=build_activity_id,
+) as activity:
+    raw = activity.register(
+        raw_data,
+        type="tabular",
+        logical_key=f"example/raw-{version}",
+        tracking_id=raw_tracking_id,
     )
-    draft.attach(data, name_in_book="data")
-    draft.publish()
+    data = activity.register(
+        processed_data,
+        type="timeseries",
+        logical_key=f"example/data-{version}",
+        used=[raw.tracking_id],
+        tracking_id=output_tracking_id,
+    )
+
+draft.attach(data, name_in_book="data")
+draft.publish()

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -58,7 +58,8 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# Under `make run` the collection, licence and authors come from bookshelf.yaml.
+# The collection, licence and authors come from bookshelf.yaml.
+# This file is executed by the recorder, so it does not construct a client itself.
 client, draft = bookshelf.setup(version=version, visibility="public")
 
 # A recorded build carries exactly one activity block.

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -68,9 +68,9 @@ processed_data = raw_data.assign(value=raw_data["value"] * 2)
 
 
 # %%
-# The collection, licence and authors come from bookshelf.yaml.
+# The collection, licence, visibility and authors come from bookshelf.yaml.
 # This file is executed by the recorder, so it does not construct a client itself.
-client, draft = bookshelf.setup(version=version, visibility="public")
+client, draft = bookshelf.setup(version=version)
 
 # A recorded build carries exactly one activity block.
 with client.activity(

--- a/tests/regression/ctt/defaults/pyproject.toml
+++ b/tests/regression/ctt/defaults/pyproject.toml
@@ -16,5 +16,6 @@ dev = [
 ]
 
 [tool.uv.sources]
-# The SDK's record and replay surface is not on PyPI yet, so track the branch that carries it.
+# No published release carries the SDK's record and replay surface, so this tracks a branch.
+# A branch is not a fixed point, so uv.lock is what makes a build reproducible.
 bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/regression/ctt/defaults/pyproject.toml
+++ b/tests/regression/ctt/defaults/pyproject.toml
@@ -5,7 +5,7 @@ description = "Test project made with copier-template-tester"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf-client[cli,publish,dataframes]>=0.3.1b4",
+    "bookshelf[publish,dataframes]",
     "pandas>=2.2",
 ]
 
@@ -14,3 +14,7 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
+
+[tool.uv.sources]
+# The SDK's record and replay surface is not on PyPI yet, so track the branch that carries it.
+bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/regression/ctt/defaults/scripts/publish-bundle.py
+++ b/tests/regression/ctt/defaults/scripts/publish-bundle.py
@@ -1,0 +1,15 @@
+"""Replay the recorded bundle to the Bookshelf API.
+
+Credentials are resolved by the SDK from the environment or a stored login.
+"""
+
+from pathlib import Path
+
+from bookshelf import Bookshelf
+from bookshelf.publisher import replay_bundle_sync
+
+with Bookshelf() as client:
+    book = replay_bundle_sync(Path("bundle"), client)
+
+detail = book.metadata
+print(f"{detail.series_name} {detail.version}_e{detail.edition:03} ({book.status})")

--- a/tests/regression/ctt/defaults/scripts/record-bundle.py
+++ b/tests/regression/ctt/defaults/scripts/record-bundle.py
@@ -1,0 +1,13 @@
+"""Execute the build file and record it into a reviewable bundle."""
+
+import json
+from pathlib import Path
+
+from bookshelf.publisher import run_record
+
+result = run_record(
+    build_path=Path("build.py"),
+    recipe_path=Path("bookshelf.yaml"),
+    bundle_path=Path("bundle"),
+)
+print(json.dumps(result, sort_keys=True))

--- a/tests/regression/ctt/defaults/scripts/validate-bundle.py
+++ b/tests/regression/ctt/defaults/scripts/validate-bundle.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from bookshelf_client.bundle import Bundle, compute_book_bundle_hash
+from bookshelf.publisher import Bundle, compute_book_bundle_hash
 
 bundle = Bundle.read(Path("bundle"))
 print(compute_book_bundle_hash(bundle.manifest))

--- a/tests/test_actions_contract.py
+++ b/tests/test_actions_contract.py
@@ -15,7 +15,7 @@ def test_record_bundle_composite_owns_the_offline_build_path() -> None:
     assert "astral-sh/setup-uv@v8.3.2" in action
     assert "actions/cache@v6" in action
     assert "uv sync --locked" in action
-    assert "bookshelf record" in action
+    assert "record_bundle.py" in action
     assert "validate_bundle.py" in action
     assert 'python3 "${GITHUB_ACTION_PATH}/cache_key.py"' in action
     assert "BOOKSHELF_ACTION_PATH" in action
@@ -57,7 +57,7 @@ def test_publish_reusable_workflow_uses_deploy_environment_secrets() -> None:
     publisher = (ACTION / "publish_bundle.py").read_text()
     assert '"outcome": "no-op"' in publisher
     assert publisher.index('"outcome": "no-op"') < publisher.index(
-        "artifacts = await replay"
+        "published = replay_bundle_sync"
     )
 
 

--- a/tests/test_ctt_directories.py
+++ b/tests/test_ctt_directories.py
@@ -22,10 +22,7 @@ ctt_directories = pytest.mark.parametrize(
 
 def setup_venv(ctt_dir, env):
     if not (ctt_dir / "uv.lock").exists():
-        pytest.skip(
-            "bookshelf-client is not published at the required "
-            "record and replay version"
-        )
+        pytest.skip("the generated feedstock has no lock file to sync against")
 
     try:
         del env["VIRTUAL_ENV"]

--- a/tests/test_feedstock_contract.py
+++ b/tests/test_feedstock_contract.py
@@ -16,12 +16,14 @@ def test_generated_feedstock_uses_record_and_replay_shape() -> None:
     makefile = (GENERATED / "Makefile").read_text()
 
     assert "collection: example" in recipe
+    assert "visibility: public" in recipe
     assert "notebook: build.py" in recipe
     assert 'version = "v0.1.0"' in build
     assert 'input_sha256 = "sha256:' in build
     assert 'Path(".cache")' in build
     assert "import bookshelf" in build
-    assert "client, draft = bookshelf.setup(" in build
+    assert "client, draft = bookshelf.setup(version=version)" in build
+    assert "visibility=" not in build
     assert "with client.activity(" in build
     assert "raw = activity.register(" in build
     assert "data = activity.register(" in build

--- a/tests/test_feedstock_contract.py
+++ b/tests/test_feedstock_contract.py
@@ -20,25 +20,29 @@ def test_generated_feedstock_uses_record_and_replay_shape() -> None:
     assert 'version = "v0.1.0"' in build
     assert 'input_sha256 = "sha256:' in build
     assert 'Path(".cache")' in build
-    assert "from bookshelf import Bookshelf" in build
-    assert "with Bookshelf() as client:" in build
+    assert "import bookshelf" in build
+    assert "client, draft = bookshelf.setup(" in build
     assert "with client.activity(" in build
     assert "raw = activity.register(" in build
     assert "data = activity.register(" in build
-    assert "draft = client.draft_book(" in build
     assert 'draft.attach(data, name_in_book="data")' in build
     assert "draft.publish()" in build
     assert "asyncio" not in build
     assert "async def" not in build
     assert "await " not in build
     assert "used=[raw.tracking_id]" in build
-    assert '"bookshelf-client[cli,publish,dataframes]' in pyproject
+    assert '"bookshelf[publish,dataframes]"' in pyproject
+    assert "climate-resource/bookshelf" in pyproject
+    assert 'branch = "feat/adopt-bookshelf-sdk"' in pyproject
     assert '"build.py" = [' in ruff
     assert '"E402"' in ruff
     assert 'src = [\n    ".",' in ruff
     assert 'known-first-party = [\n    "build",' in ruff
+    assert "scripts/record-bundle.py" in makefile
     assert "scripts/validate-bundle.py" in makefile
-    assert (GENERATED / "scripts" / "validate-bundle.py").exists()
+    assert "scripts/publish-bundle.py" in makefile
+    for script in ("record-bundle.py", "validate-bundle.py", "publish-bundle.py"):
+        assert (GENERATED / "scripts" / script).exists()
 
 
 def test_generated_example_input_matches_its_declared_content_hash() -> None:


### PR DESCRIPTION
Moves the generated feedstock onto the Bookshelf SDK that now lives in the `bookshelf` package, on the `feat/adopt-bookshelf-sdk` branch of `climate-resource/bookshelf`.

The template was pointing at a package and a command surface that do not exist:

- `bookshelf-client` has never been published to PyPI, so `uv sync` in a generated feedstock could not resolve.
- `bookshelf record` and `bookshelf publish` are not commands on the SDK. Its CLI is `auth`, `cache`, `search` and `show`.

## Changes

- Depends on `bookshelf[publish,dataframes]` with a `[tool.uv.sources]` git entry for the SDK branch. The `cli` extra is gone because those dependencies are core now.
- Drops `UV_PRERELEASE = allow` from the generated Makefile. A git source does not need it.
- `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence, visibility and authors come from `bookshelf.yaml` rather than being repeated in the build.
- Collapses the fetch and process activities into a single activity block. A recorded build supports exactly one.
- Records, validates and replays through `bookshelf.publisher` from `scripts/record-bundle.py`, `scripts/validate-bundle.py` and `scripts/publish-bundle.py`.
- The colocated action gains `record_bundle.py` and its scripts import `bookshelf` instead of `bookshelf_client`. `publish_bundle.py` is now synchronous and replays via `replay_bundle_sync`, keeping the `no-op` and `published` outcomes.

## Validation

Generated a feedstock from this branch into a scratch directory:

- `uv sync` resolves the SDK from the branch.
- `make run` records and validates a bundle.
- Two independent recordings produce the same bundle hash, so the build is still deterministic.

`pytest tests` and `pre-commit run --all-files` both pass.

## Follow-up

Pinning to a branch means `uv sync --locked` in CI is only reproducible through each feedstock's `uv.lock`. Swap the git source for a version pin once the SDK is released.

## Developer experience fixes

An adversarial pass over the authoring workflow, driving a fresh scaffold rather than reading the diff, found two blockers a new author hit before writing any code.

- `make run` failed on an untouched scaffold. Recording derives provenance from git, which needs both an `origin` remote and a commit to point at, and `_tasks` created neither. The SDK reported this as "not inside a git repository", which is false and sent you looking in the wrong place.
- The first CI run failed. The action syncs with `--locked` and the scaffold shipped no `uv.lock`.

`_tasks` now sets the remote from `project_url`, writes the lock and makes the initial commit, each step guarded so re-running the template never rewrites an existing repository. A fresh scaffold now passes `uv sync --locked` and `make run` with no manual steps.

Two smaller things from the same pass:

- `InputHashMismatchError` was raised bare, with no expected, no actual and no path. It is the likeliest error an author will meet, so it now names all three and both ways out.
- The README claimed identical inputs give identical bytes. The bundle carries the executed notebook, so a comment-only edit to `build.py` moves the bundle hash and publishing then mints an edition whose data is unchanged. Verified: `cfdbdd6b…` to `8cbadfe3…` with both data resources byte-identical. The README now says so.

## Closed upstream by `climate-resource/bookshelf#137`

Three gaps this branch could not fix on its own have since landed in the SDK.

- `RecordRecipe` now carries `visibility`, so `bookshelf.yaml` declares it and `build.py` no longer hardcodes `public`. Adopted here.
- Running `build.py` directly said `direct setup requires collection`. It now says no recording is active and names both ways forward.
- `derive_code_ref` now names the unmet requirement rather than blaming a missing repository for every failure.

## Known gaps, not addressed here

- `make publish` targets production by default with no dry-run and no confirmation. Left as is, because CI is the intended publish path.
- The one-activity-per-build limit is only discovered at runtime.
- `tests/test_ctt_directories.py` now runs locally, because `_tasks` writes the lock its guard waits for. It still skips in CI, which does not run ctt before pytest. Making CI generate and lock a feedstock would have caught both blockers above, and is the single highest-value test to add next.

