### PR TITLE
Take the Bookshelf SDK from PyPI

### DIFF
--- a/changelog/11.breaking.md
+++ b/changelog/11.breaking.md
@@ -1,6 +1,6 @@
 Moves the generated feedstock onto the Bookshelf SDK that now lives in the `bookshelf` package.
 
-- The dependency is `bookshelf[publish,dataframes]`, sourced from the `feat/adopt-bookshelf-sdk` branch until the SDK is released.
+- The dependency is `bookshelf[publish,dataframes]>=1.0.0b1`, taken from PyPI.
 - `build.py` calls `bookshelf.setup()` for its client and draft, so the collection, licence, visibility and authors come from `bookshelf.yaml`.
 - The build carries a single activity block, which is all a recorded build supports.
 - Recording, validating and replaying a bundle run through the `bookshelf` CLI.

--- a/changelog/20.breaking.md
+++ b/changelog/20.breaking.md
@@ -1,0 +1,4 @@
+Takes the SDK from PyPI rather than from a git branch, now that `1.0.0b1` is published.
+The generated `pyproject.toml` depends on `bookshelf[publish,dataframes]>=1.0.0b1`
+and carries no `[tool.uv.sources]`.
+The specifier names the beta, because a bare one would resolve to the last stable release.

--- a/template/bookshelf.yaml.jinja
+++ b/template/bookshelf.yaml.jinja
@@ -1,5 +1,5 @@
 # The recipe carries every fact about the books this feedstock produces.
-# Format: https://github.com/climate-resource/bookshelf/blob/feat/adopt-bookshelf-sdk/docs/explanation/recipe-format.md
+# Format: https://github.com/climate-resource/bookshelf/blob/main/docs/explanation/recipe-format.md
 volume:
   name: {{ dataset_name }}
   maintainers:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -5,7 +5,7 @@ description = {{ dataset_description | tojson }}
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]",
+    "bookshelf[publish,dataframes]>=1.0.0b1",
     "pandas>=2.2",
 ]
 
@@ -14,7 +14,3 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
-
-[tool.uv.sources]
-# Using an unpublished branch for testing
-bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/regression/ctt/defaults/bookshelf.yaml
+++ b/tests/regression/ctt/defaults/bookshelf.yaml
@@ -1,5 +1,5 @@
 # The recipe carries every fact about the books this feedstock produces.
-# Format: https://github.com/climate-resource/bookshelf/blob/feat/adopt-bookshelf-sdk/docs/explanation/recipe-format.md
+# Format: https://github.com/climate-resource/bookshelf/blob/main/docs/explanation/recipe-format.md
 volume:
   name: example
   maintainers:

--- a/tests/regression/ctt/defaults/pyproject.toml
+++ b/tests/regression/ctt/defaults/pyproject.toml
@@ -5,7 +5,7 @@ description = "Test project made with copier-template-tester"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]",
+    "bookshelf[publish,dataframes]>=1.0.0b1",
     "pandas>=2.2",
 ]
 
@@ -14,7 +14,3 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
-
-[tool.uv.sources]
-# Using an unpublished branch for testing
-bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/regression/ctt/hyphenated/bookshelf.yaml
+++ b/tests/regression/ctt/hyphenated/bookshelf.yaml
@@ -1,5 +1,5 @@
 # The recipe carries every fact about the books this feedstock produces.
-# Format: https://github.com/climate-resource/bookshelf/blob/feat/adopt-bookshelf-sdk/docs/explanation/recipe-format.md
+# Format: https://github.com/climate-resource/bookshelf/blob/main/docs/explanation/recipe-format.md
 volume:
   name: primap-hist-2024
   maintainers:

--- a/tests/regression/ctt/hyphenated/pyproject.toml
+++ b/tests/regression/ctt/hyphenated/pyproject.toml
@@ -5,7 +5,7 @@ description = "Historical national emissions, hyphenated and numbered."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]",
+    "bookshelf[publish,dataframes]>=1.0.0b1",
     "pandas>=2.2",
 ]
 
@@ -14,7 +14,3 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
-
-[tool.uv.sources]
-# Using an unpublished branch for testing
-bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/regression/ctt/punctuation/bookshelf.yaml
+++ b/tests/regression/ctt/punctuation/bookshelf.yaml
@@ -1,5 +1,5 @@
 # The recipe carries every fact about the books this feedstock produces.
-# Format: https://github.com/climate-resource/bookshelf/blob/feat/adopt-bookshelf-sdk/docs/explanation/recipe-format.md
+# Format: https://github.com/climate-resource/bookshelf/blob/main/docs/explanation/recipe-format.md
 volume:
   name: ngfs-scenarios
   maintainers:

--- a/tests/regression/ctt/punctuation/pyproject.toml
+++ b/tests/regression/ctt/punctuation/pyproject.toml
@@ -5,7 +5,7 @@ description = "Scenario data for O\u0027Brien\u0027s review: quoted, apostrophis
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]",
+    "bookshelf[publish,dataframes]>=1.0.0b1",
     "pandas>=2.2",
 ]
 
@@ -14,7 +14,3 @@ dev = [
     "mypy>=1.11.2",
     "towncrier>=25.8.0",
 ]
-
-[tool.uv.sources]
-# Using an unpublished branch for testing
-bookshelf = { git = "https://github.com/climate-resource/bookshelf", branch = "feat/adopt-bookshelf-sdk", subdirectory = "packages/bookshelf" }

--- a/tests/test_feedstock_contract.py
+++ b/tests/test_feedstock_contract.py
@@ -24,9 +24,10 @@ def test_generated_feedstock_uses_record_and_replay_shape(feedstock: Feedstock) 
     assert "asyncio" not in build
     assert "async def" not in build
     assert "await " not in build
-    assert '"bookshelf[publish,dataframes]"' in pyproject
-    assert "climate-resource/bookshelf" in pyproject
-    assert 'branch = "feat/adopt-bookshelf-sdk"' in pyproject
+    # The SDK is a beta on PyPI, so the specifier names it
+    # and nothing sources it from git.
+    assert '"bookshelf[publish,dataframes]>=1.0.0b1"' in pyproject
+    assert "[tool.uv.sources]" not in pyproject
     assert '"build.py" = [' in ruff
     assert '"E402"' in ruff
     assert 'src = [\n    ".",' in ruff


### PR DESCRIPTION
## Description

Takes the Bookshelf SDK from PyPI now that `1.0.0b1` is published, rather than from the `feat/adopt-bookshelf-sdk` branch.

- A generated feedstock depends on `bookshelf[publish,dataframes]>=1.0.0b1` and carries no `[tool.uv.sources]`.
- The specifier names the beta, because a bare one resolves to the last stable release and PyPI still reports `0.4.3` as latest.
- The recipe format link in `bookshelf.yaml` points at `main` rather than at the development branch.

The changelog entry from #11 said the dependency was sourced from a branch until the SDK was released, so it is corrected here rather than left to ship wrong.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
