### PR TITLE
Offer alpha and beta in the bump workflows

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -18,6 +18,8 @@ on:
           - patch
           - minor
           - major
+          - alpha
+          - beta
           - "patch alpha"
           - "minor alpha"
           - "major alpha"

--- a/changelog/23.improvement.md
+++ b/changelog/23.improvement.md
@@ -1,0 +1,2 @@
+Added `alpha` and `beta` to the bump workflow's version rules,
+so a feedstock can cut a pre-release without editing the workflow first.

--- a/template/.github/workflows/bump.yaml
+++ b/template/.github/workflows/bump.yaml
@@ -23,6 +23,8 @@ on:
           - minor
           - major
           - stable
+          - alpha
+          - beta
           - "patch alpha"
           - "minor alpha"
           - "major alpha"

--- a/tests/regression/ctt/defaults/.github/workflows/bump.yaml
+++ b/tests/regression/ctt/defaults/.github/workflows/bump.yaml
@@ -23,6 +23,8 @@ on:
           - minor
           - major
           - stable
+          - alpha
+          - beta
           - "patch alpha"
           - "minor alpha"
           - "major alpha"

--- a/tests/regression/ctt/hyphenated/.github/workflows/bump.yaml
+++ b/tests/regression/ctt/hyphenated/.github/workflows/bump.yaml
@@ -23,6 +23,8 @@ on:
           - minor
           - major
           - stable
+          - alpha
+          - beta
           - "patch alpha"
           - "minor alpha"
           - "major alpha"

--- a/tests/regression/ctt/punctuation/.github/workflows/bump.yaml
+++ b/tests/regression/ctt/punctuation/.github/workflows/bump.yaml
@@ -23,6 +23,8 @@ on:
           - minor
           - major
           - stable
+          - alpha
+          - beta
           - "patch alpha"
           - "minor alpha"
           - "major alpha"


### PR DESCRIPTION
`uv version --bump` accepts `alpha` and `beta`, but neither was in the workflow_dispatch dropdown, so cutting a pre-release meant editing the workflow first. This came up trying to cut a 0.3.0 beta of the template to pilot.

- Adds both to this repository's bump workflow, which is what cuts a template release.
- Adds both to the template's, so a generated feedstock can cut a pre-release too.
- Regenerates the three `tests/regression/ctt` fixtures with `make ctt`.

From the current `0.3.0a1`, `beta` gives `0.3.0b1`. The compound rules and the defaults are unchanged.