### PR TITLE
Credit each resource on the thing it made

### DIFF
--- a/changelog/24.feature.md
+++ b/changelog/24.feature.md
@@ -1,0 +1,10 @@
+Credits each resource on the thing it made, now that the SDK carries per-resource catalogue metadata.
+The declared input states its `authors` and a `description` under `resources:` in the recipe,
+and the build file passes the same fields to `build.book.write`.
+A resource inherits no credit from its book, so a feedstock reproducing somebody else's data
+can name them on the input while the derived output stays with whoever ran the build.
+
+The generated `pyproject.toml` depends on `bookshelf[publish,dataframes]>=1.0.0b3`,
+which is the release those fields landed in.
+The generated README also drops its claim that a `path:` input is catalogued as a pointer,
+because the platform re-hosts one and links back to the commit the file was read at.

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -69,6 +69,16 @@ Each takes `--json` for a machine readable summary, and carries its meaning in t
 CI records every version `books:` declares, and the publish workflow replays every one of them.
 Publishing an unchanged book is idempotent, so a version that has not moved keeps its edition.
 
+### Crediting the data
+
+`volume.maintainers` are whoever runs this feedstock, which is a contact rather than a credit.
+`authors` credit whoever produced the data,
+so a feedstock that reproduces somebody else's dataset names them.
+
+A resource inherits no credit from its book, so each one states its own authors.
+A declared input states them under `resources:` in the recipe,
+and an output passes them to `build.book.write(...)` beside its description.
+
 ### Worked examples
 
 The SDK's [examples README](https://github.com/climate-resource/bookshelf/blob/main/examples/README.md)
@@ -97,9 +107,11 @@ the `build.ipynb` and `build.html` documents included.
 Pass `visibility=` on a single `build.book.write(...)` call to narrow that one resource,
 so a public book can still hold a member only your organisation may read.
 
-A `path:` input is catalogued as a pointer at that repository relative path.
-The platform never re-hosts it, so once the real upstream data is in place,
-move the resource to a `uri:` with the `sha256:` the fetch is checked against.
+A `path:` input is re-hosted, because a repository path is no address the platform can resolve.
+Its metadata links back to the commit the file was read at.
+Once the real upstream data is in place,
+move the resource to a `uri:` with the `sha256:` the fetch is checked against,
+and the platform catalogues it as a pointer instead.
 
 The recorded bundle also carries the executed script and notebook, so its bundle hash covers the build source.
 Any edit to `build.py`, a comment included, produces a new bundle hash.

--- a/template/bookshelf.yaml.jinja
+++ b/template/bookshelf.yaml.jinja
@@ -16,13 +16,20 @@ defaults:
   publisher: Climate Resource
   repository_url: {{ project_url }}
   visibility: public
+  # `authors` credit whoever produced the data, so name the upstream team here
+  # once this feedstock reproduces somebody else's dataset.
   authors:
     - name: {{ author | tojson }}
       email: {{ author_email }}
   resources:
     # A resource type never moves between books, so it is stated once here.
+    # A resource inherits no credit from its book, so it names its own authors.
     raw:
       type: tabular
+      description: The input this build reads, as it was published upstream.
+      authors:
+        - name: {{ author | tojson }}
+          email: {{ author_email }}
 
 build:
   notebook: build.py

--- a/template/build.py.jinja
+++ b/template/build.py.jinja
@@ -20,6 +20,7 @@ build = bookshelf.setup()
 #
 # `build.use` resolves a resource named in the recipe,
 # and registers them as an input of this build.
+# The recipe states the authorship of `raw`, so nothing about it is repeated here.
 
 # %%
 raw = build.use("raw")
@@ -43,7 +44,21 @@ processed_data.columns = [str(column) for column in processed_data.columns]
 # %% [markdown]
 # # Publish
 #
+# The recipe never names what a build writes,
+# so an output states its own catalogue metadata here, credited to whoever derived it.
 
 # %%
-build.book.write("data", processed_data, type="timeseries", used=[raw])
+build.book.write(
+    "data",
+    processed_data,
+    type="timeseries",
+    used=[raw],
+    description="The processed output this build derives from `raw`.",
+    authors=[
+        {
+            "name": {{ author | tojson }},
+            "email": {{ author_email | tojson }},
+        }
+    ],
+)
 build.book.publish()

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -5,7 +5,7 @@ description = {{ dataset_description | tojson }}
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]>=1.0.0b2",
+    "bookshelf[publish,dataframes]>=1.0.0b3",
     "pandas>=2.2",
 ]
 

--- a/tests/regression/ctt/defaults/README.md
+++ b/tests/regression/ctt/defaults/README.md
@@ -69,6 +69,16 @@ Each takes `--json` for a machine readable summary, and carries its meaning in t
 CI records every version `books:` declares, and the publish workflow replays every one of them.
 Publishing an unchanged book is idempotent, so a version that has not moved keeps its edition.
 
+### Crediting the data
+
+`volume.maintainers` are whoever runs this feedstock, which is a contact rather than a credit.
+`authors` credit whoever produced the data,
+so a feedstock that reproduces somebody else's dataset names them.
+
+A resource inherits no credit from its book, so each one states its own authors.
+A declared input states them under `resources:` in the recipe,
+and an output passes them to `build.book.write(...)` beside its description.
+
 ### Worked examples
 
 The SDK's [examples README](https://github.com/climate-resource/bookshelf/blob/main/examples/README.md)
@@ -97,9 +107,11 @@ the `build.ipynb` and `build.html` documents included.
 Pass `visibility=` on a single `build.book.write(...)` call to narrow that one resource,
 so a public book can still hold a member only your organisation may read.
 
-A `path:` input is catalogued as a pointer at that repository relative path.
-The platform never re-hosts it, so once the real upstream data is in place,
-move the resource to a `uri:` with the `sha256:` the fetch is checked against.
+A `path:` input is re-hosted, because a repository path is no address the platform can resolve.
+Its metadata links back to the commit the file was read at.
+Once the real upstream data is in place,
+move the resource to a `uri:` with the `sha256:` the fetch is checked against,
+and the platform catalogues it as a pointer instead.
 
 The recorded bundle also carries the executed script and notebook, so its bundle hash covers the build source.
 Any edit to `build.py`, a comment included, produces a new bundle hash.

--- a/tests/regression/ctt/defaults/bookshelf.yaml
+++ b/tests/regression/ctt/defaults/bookshelf.yaml
@@ -16,13 +16,20 @@ defaults:
   publisher: Climate Resource
   repository_url: https://github.com/climate-resource/ctt-project
   visibility: public
+  # `authors` credit whoever produced the data, so name the upstream team here
+  # once this feedstock reproduces somebody else's dataset.
   authors:
     - name: "Tim Slim"
       email: timslim@climate-resource.com
   resources:
     # A resource type never moves between books, so it is stated once here.
+    # A resource inherits no credit from its book, so it names its own authors.
     raw:
       type: tabular
+      description: The input this build reads, as it was published upstream.
+      authors:
+        - name: "Tim Slim"
+          email: timslim@climate-resource.com
 
 build:
   notebook: build.py

--- a/tests/regression/ctt/defaults/build.py
+++ b/tests/regression/ctt/defaults/build.py
@@ -20,6 +20,7 @@ build = bookshelf.setup()
 #
 # `build.use` resolves a resource named in the recipe,
 # and registers them as an input of this build.
+# The recipe states the authorship of `raw`, so nothing about it is repeated here.
 
 # %%
 raw = build.use("raw")
@@ -43,7 +44,21 @@ processed_data.columns = [str(column) for column in processed_data.columns]
 # %% [markdown]
 # # Publish
 #
+# The recipe never names what a build writes,
+# so an output states its own catalogue metadata here, credited to whoever derived it.
 
 # %%
-build.book.write("data", processed_data, type="timeseries", used=[raw])
+build.book.write(
+    "data",
+    processed_data,
+    type="timeseries",
+    used=[raw],
+    description="The processed output this build derives from `raw`.",
+    authors=[
+        {
+            "name": "Tim Slim",
+            "email": "timslim@climate-resource.com",
+        }
+    ],
+)
 build.book.publish()

--- a/tests/regression/ctt/defaults/pyproject.toml
+++ b/tests/regression/ctt/defaults/pyproject.toml
@@ -5,7 +5,7 @@ description = "Test project made with copier-template-tester"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]>=1.0.0b2",
+    "bookshelf[publish,dataframes]>=1.0.0b3",
     "pandas>=2.2",
 ]
 

--- a/tests/regression/ctt/hyphenated/README.md
+++ b/tests/regression/ctt/hyphenated/README.md
@@ -69,6 +69,16 @@ Each takes `--json` for a machine readable summary, and carries its meaning in t
 CI records every version `books:` declares, and the publish workflow replays every one of them.
 Publishing an unchanged book is idempotent, so a version that has not moved keeps its edition.
 
+### Crediting the data
+
+`volume.maintainers` are whoever runs this feedstock, which is a contact rather than a credit.
+`authors` credit whoever produced the data,
+so a feedstock that reproduces somebody else's dataset names them.
+
+A resource inherits no credit from its book, so each one states its own authors.
+A declared input states them under `resources:` in the recipe,
+and an output passes them to `build.book.write(...)` beside its description.
+
 ### Worked examples
 
 The SDK's [examples README](https://github.com/climate-resource/bookshelf/blob/main/examples/README.md)
@@ -97,9 +107,11 @@ the `build.ipynb` and `build.html` documents included.
 Pass `visibility=` on a single `build.book.write(...)` call to narrow that one resource,
 so a public book can still hold a member only your organisation may read.
 
-A `path:` input is catalogued as a pointer at that repository relative path.
-The platform never re-hosts it, so once the real upstream data is in place,
-move the resource to a `uri:` with the `sha256:` the fetch is checked against.
+A `path:` input is re-hosted, because a repository path is no address the platform can resolve.
+Its metadata links back to the commit the file was read at.
+Once the real upstream data is in place,
+move the resource to a `uri:` with the `sha256:` the fetch is checked against,
+and the platform catalogues it as a pointer instead.
 
 The recorded bundle also carries the executed script and notebook, so its bundle hash covers the build source.
 Any edit to `build.py`, a comment included, produces a new bundle hash.

--- a/tests/regression/ctt/hyphenated/bookshelf.yaml
+++ b/tests/regression/ctt/hyphenated/bookshelf.yaml
@@ -16,13 +16,20 @@ defaults:
   publisher: Climate Resource
   repository_url: https://github.com/climate-resource/bookshelf-primap-hist-2024
   visibility: public
+  # `authors` credit whoever produced the data, so name the upstream team here
+  # once this feedstock reproduces somebody else's dataset.
   authors:
     - name: "Ada Lovelace"
       email: ada.lovelace@climate-resource.com
   resources:
     # A resource type never moves between books, so it is stated once here.
+    # A resource inherits no credit from its book, so it names its own authors.
     raw:
       type: tabular
+      description: The input this build reads, as it was published upstream.
+      authors:
+        - name: "Ada Lovelace"
+          email: ada.lovelace@climate-resource.com
 
 build:
   notebook: build.py

--- a/tests/regression/ctt/hyphenated/build.py
+++ b/tests/regression/ctt/hyphenated/build.py
@@ -20,6 +20,7 @@ build = bookshelf.setup()
 #
 # `build.use` resolves a resource named in the recipe,
 # and registers them as an input of this build.
+# The recipe states the authorship of `raw`, so nothing about it is repeated here.
 
 # %%
 raw = build.use("raw")
@@ -43,7 +44,21 @@ processed_data.columns = [str(column) for column in processed_data.columns]
 # %% [markdown]
 # # Publish
 #
+# The recipe never names what a build writes,
+# so an output states its own catalogue metadata here, credited to whoever derived it.
 
 # %%
-build.book.write("data", processed_data, type="timeseries", used=[raw])
+build.book.write(
+    "data",
+    processed_data,
+    type="timeseries",
+    used=[raw],
+    description="The processed output this build derives from `raw`.",
+    authors=[
+        {
+            "name": "Ada Lovelace",
+            "email": "ada.lovelace@climate-resource.com",
+        }
+    ],
+)
 build.book.publish()

--- a/tests/regression/ctt/hyphenated/pyproject.toml
+++ b/tests/regression/ctt/hyphenated/pyproject.toml
@@ -5,7 +5,7 @@ description = "Historical national emissions, hyphenated and numbered."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]>=1.0.0b2",
+    "bookshelf[publish,dataframes]>=1.0.0b3",
     "pandas>=2.2",
 ]
 

--- a/tests/regression/ctt/punctuation/README.md
+++ b/tests/regression/ctt/punctuation/README.md
@@ -69,6 +69,16 @@ Each takes `--json` for a machine readable summary, and carries its meaning in t
 CI records every version `books:` declares, and the publish workflow replays every one of them.
 Publishing an unchanged book is idempotent, so a version that has not moved keeps its edition.
 
+### Crediting the data
+
+`volume.maintainers` are whoever runs this feedstock, which is a contact rather than a credit.
+`authors` credit whoever produced the data,
+so a feedstock that reproduces somebody else's dataset names them.
+
+A resource inherits no credit from its book, so each one states its own authors.
+A declared input states them under `resources:` in the recipe,
+and an output passes them to `build.book.write(...)` beside its description.
+
 ### Worked examples
 
 The SDK's [examples README](https://github.com/climate-resource/bookshelf/blob/main/examples/README.md)
@@ -97,9 +107,11 @@ the `build.ipynb` and `build.html` documents included.
 Pass `visibility=` on a single `build.book.write(...)` call to narrow that one resource,
 so a public book can still hold a member only your organisation may read.
 
-A `path:` input is catalogued as a pointer at that repository relative path.
-The platform never re-hosts it, so once the real upstream data is in place,
-move the resource to a `uri:` with the `sha256:` the fetch is checked against.
+A `path:` input is re-hosted, because a repository path is no address the platform can resolve.
+Its metadata links back to the commit the file was read at.
+Once the real upstream data is in place,
+move the resource to a `uri:` with the `sha256:` the fetch is checked against,
+and the platform catalogues it as a pointer instead.
 
 The recorded bundle also carries the executed script and notebook, so its bundle hash covers the build source.
 Any edit to `build.py`, a comment included, produces a new bundle hash.

--- a/tests/regression/ctt/punctuation/bookshelf.yaml
+++ b/tests/regression/ctt/punctuation/bookshelf.yaml
@@ -16,13 +16,20 @@ defaults:
   publisher: Climate Resource
   repository_url: https://github.com/climate-resource/bookshelf-ngfs-scenarios
   visibility: public
+  # `authors` credit whoever produced the data, so name the upstream team here
+  # once this feedstock reproduces somebody else's dataset.
   authors:
     - name: "Ren\u00e9e O\u0027Brien"
       email: renee.obrien@climate-resource.com
   resources:
     # A resource type never moves between books, so it is stated once here.
+    # A resource inherits no credit from its book, so it names its own authors.
     raw:
       type: tabular
+      description: The input this build reads, as it was published upstream.
+      authors:
+        - name: "Ren\u00e9e O\u0027Brien"
+          email: renee.obrien@climate-resource.com
 
 build:
   notebook: build.py

--- a/tests/regression/ctt/punctuation/build.py
+++ b/tests/regression/ctt/punctuation/build.py
@@ -20,6 +20,7 @@ build = bookshelf.setup()
 #
 # `build.use` resolves a resource named in the recipe,
 # and registers them as an input of this build.
+# The recipe states the authorship of `raw`, so nothing about it is repeated here.
 
 # %%
 raw = build.use("raw")
@@ -43,7 +44,21 @@ processed_data.columns = [str(column) for column in processed_data.columns]
 # %% [markdown]
 # # Publish
 #
+# The recipe never names what a build writes,
+# so an output states its own catalogue metadata here, credited to whoever derived it.
 
 # %%
-build.book.write("data", processed_data, type="timeseries", used=[raw])
+build.book.write(
+    "data",
+    processed_data,
+    type="timeseries",
+    used=[raw],
+    description="The processed output this build derives from `raw`.",
+    authors=[
+        {
+            "name": "Ren\u00e9e O\u0027Brien",
+            "email": "renee.obrien@climate-resource.com",
+        }
+    ],
+)
 build.book.publish()

--- a/tests/regression/ctt/punctuation/pyproject.toml
+++ b/tests/regression/ctt/punctuation/pyproject.toml
@@ -5,7 +5,7 @@ description = "Scenario data for O\u0027Brien\u0027s review: quoted, apostrophis
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bookshelf[publish,dataframes]>=1.0.0b2",
+    "bookshelf[publish,dataframes]>=1.0.0b3",
     "pandas>=2.2",
 ]
 

--- a/tests/test_feedstock_contract.py
+++ b/tests/test_feedstock_contract.py
@@ -13,10 +13,9 @@ def test_generated_feedstock_uses_record_and_replay_shape(feedstock: Feedstock) 
     assert "import bookshelf" in build
     assert "build = bookshelf.setup()" in build
     assert 'raw = build.use("raw")' in build
-    assert (
-        'build.book.write("data", processed_data, type="timeseries", used=[raw])'
-        in build
-    )
+    assert 'build.book.write(\n    "data",\n    processed_data,' in build
+    assert 'type="timeseries",' in build
+    assert "used=[raw]," in build
     assert "build.book.publish()" in build
     # The recipe states the version and the visibility, so the build file does not.
     assert "version =" not in build
@@ -26,7 +25,7 @@ def test_generated_feedstock_uses_record_and_replay_shape(feedstock: Feedstock) 
     assert "await " not in build
     # The SDK is a beta on PyPI, so the specifier names it
     # and nothing sources it from git.
-    assert '"bookshelf[publish,dataframes]>=1.0.0b2"' in pyproject
+    assert '"bookshelf[publish,dataframes]>=1.0.0b3"' in pyproject
     assert "[tool.uv.sources]" not in pyproject
     assert '"build.py" = [' in ruff
     assert '"E402"' in ruff

--- a/tests/test_generated_metadata.py
+++ b/tests/test_generated_metadata.py
@@ -40,7 +40,40 @@ def test_generated_recipe_parses_and_round_trips_the_answers(
     assert recipe["defaults"]["description"] == feedstock.answers["dataset_description"]
     assert recipe["defaults"]["repository_url"] == feedstock.answers["project_url"]
     assert recipe["defaults"]["authors"] == [maintainer]
+    assert recipe["defaults"]["resources"]["raw"]["authors"] == [maintainer]
     assert recipe["build"]["notebook"] == "build.py"
+
+
+def test_generated_build_file_credits_the_output_it_writes(
+    feedstock: Feedstock,
+) -> None:
+    """A resource inherits no credit from its book.
+
+    So the output the build writes names its own authors.
+    """
+    tree = ast.parse(feedstock.read("build.py"))
+    writes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "write"
+    ]
+    authors = [
+        ast.literal_eval(keyword.value)
+        for call in writes
+        for keyword in call.keywords
+        if keyword.arg == "authors"
+    ]
+
+    assert authors == [
+        [
+            {
+                "name": feedstock.answers["author"],
+                "email": feedstock.answers["author_email"],
+            }
+        ]
+    ]
 
 
 def test_generated_workflows_parse(feedstock: Feedstock) -> None:


### PR DESCRIPTION
Takes the SDK from `1.0.0b3`, which lets a resource carry its own catalogue metadata.

- The declared input states its `authors` and a `description` under `resources:` in the recipe.
- The build file passes the same fields to `build.book.write` for the output it derives.
- A resource inherits no credit from its book, so a feedstock reproducing somebody else's data can name them on the input while the derived output stays with whoever ran the build.
- The generated README gains a "Crediting the data" section pinning down what `authors` and `volume.maintainers` each claim.
- The generated README also drops its claim that a `path:` input is catalogued as a pointer, because the platform re-hosts one and links back to the commit the file was read at. The provenance test on main already asserted this.

Verified by recording a bundle from the generated feedstock. The manifest carries `authors` on both `raw` and `data` at schema version 3.2.

https://claude.ai/code/session_01Wr3vzfDdSU9JbRk6Mzc92k